### PR TITLE
Use the omnisharp/omnisharp shell script on *nix systems

### DIFF
--- a/node/omnisharp.js
+++ b/node/omnisharp.js
@@ -58,7 +58,8 @@ maxerr: 50, node: true */
     }
 
     function getOmnisharpLocation() {
-        return process.env['OMNISHARP'] || path.join(__dirname, '..', 'omnisharp', 'omnisharp.cmd');
+        var script = process.platform === 'win32' ? 'omnisharp.cmd' : 'omnisharp';
+        return process.env['OMNISHARP'] || path.join(__dirname, '..', 'omnisharp', script);
     }
 
     function startOmnisharp(projectLocation, callback) {

--- a/omnisharp/approot/packages/KRE-CLR-x86.1.0.0-beta2/bin/klr
+++ b/omnisharp/approot/packages/KRE-CLR-x86.1.0.0-beta2/bin/klr
@@ -8,6 +8,8 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-export SET KRE_APPBASE="$DIR/approot/packages/OmniSharp/1.0.0/root"
-
-"$DIR/approot/packages/KRE-CLR-x86.1.0.0-beta2/bin/klr" Microsoft.Framework.ApplicationHost omnisharp "$@"
+if [ -f "$DIR/mono" ]; then
+  "$DIR/mono" $MONO_OPTIONS "$DIR/klr.mono.managed.dll" "$@"
+else
+  mono $MONO_OPTIONS "$DIR/klr.mono.managed.dll" "$@"
+fi


### PR DESCRIPTION
There I was, wondering why this didn't work on Linux, and it's calling `omnisharp.cmd`.

Fixed.