### PR TITLE
codelens turning off and reloading through preferences

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,6 +42,7 @@ define(function (require, exports, module) {
         menu.addMenuDivider();
         menu.addMenuItem(OmniCommands.FIX_USINGS);
         menu.addMenuItem(OmniCommands.FORMAT_DOCUMENT);
+        menu.addMenuItem(OmniCommands.RELOAD_REFERENCE_DISPLAY);
 
         disable();
     }

--- a/modules/contextMenu.js
+++ b/modules/contextMenu.js
@@ -17,12 +17,14 @@ define(function (require, exports, module) {
         CommandManager.get(OmniCommands.GO_TO_DEFINITION).setEnabled(true);
         CommandManager.get(OmniCommands.RENAME).setEnabled(true);
         CommandManager.get(OmniCommands.FIX_CODE_ISSUE).setEnabled(true);
+        CommandManager.get(OmniCommands.RELOAD_REFERENCE_DISPLAY).setEnabled(true);
     }
 
     function disable() {
         CommandManager.get(OmniCommands.GO_TO_DEFINITION).setEnabled(false);
         CommandManager.get(OmniCommands.RENAME).setEnabled(false);
         CommandManager.get(OmniCommands.FIX_CODE_ISSUE).setEnabled(false);
+        CommandManager.get(OmniCommands.RELOAD_REFERENCE_DISPLAY).setEnabled(false);
     }
 
     function beforeContextMenuOpen() {
@@ -30,10 +32,12 @@ define(function (require, exports, module) {
             contextMenu.addMenuItem(OmniCommands.GO_TO_DEFINITION, Preferences.get().keyboardShortcuts.goToDefinition);
             contextMenu.addMenuItem(OmniCommands.RENAME, Preferences.get().keyboardShortcuts.rename);
             contextMenu.addMenuItem(OmniCommands.FIX_CODE_ISSUE, Preferences.get().keyboardShortcuts.fixCodeIssue);
+            contextMenu.addMenuItem(OmniCommands.RELOAD_REFERENCE_DISPLAY, Preferences.get().keyboardShortcuts.reloadReferenceDisplay);
         } else {
             contextMenu.removeMenuItem(OmniCommands.GO_TO_DEFINITION);
             contextMenu.removeMenuItem(OmniCommands.RENAME);
             contextMenu.removeMenuItem(OmniCommands.FIX_CODE_ISSUE);
+            contextMenu.removeMenuItem(OmniCommands.RELOAD_REFERENCE_DISPLAY);
         }
     }
 

--- a/modules/omniCommands.js
+++ b/modules/omniCommands.js
@@ -14,4 +14,5 @@ define(function (require, exports, module) {
     exports.STOP_OMNISHARP = packageString + 'stopOmnisharp';
     exports.FIX_CODE_ISSUE = packageString + 'fixCodeIssue';
     exports.OPEN_PREFERENCES = packageString + 'openPreferences';
+    exports.RELOAD_REFERENCE_DISPLAY = packageString + 'reloadReferenceDisplay';
 });

--- a/modules/omniHandlers.js
+++ b/modules/omniHandlers.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
         OmniStrings = require('modules/omniStrings'),
         RenameCommand = require('commands/rename'),
         goToDefinitionCommand = require('commands/goToDefinition'),
+        ReferenceDisplay = require('modules/referenceDisplay'),
         Preferences = require('modules/preferences');
 
     function fixCodeIssue() {
@@ -34,6 +35,7 @@ define(function (require, exports, module) {
         CommandManager.register(OmniStrings.CMD_STOP_OMNISHARP, OmniCommands.STOP_OMNISHARP, Omnisharp.stop);
         CommandManager.register(OmniStrings.CMD_FIX_CODE_ISSUE, OmniCommands.FIX_CODE_ISSUE, fixCodeIssue);
         CommandManager.register(OmniStrings.CMD_OPEN_PREFERENCES, OmniCommands.OPEN_PREFERENCES, Preferences.open);
+        CommandManager.register(OmniStrings.CMD_RELOAD_REFERENCE_DISPLAY, OmniCommands.RELOAD_REFERENCE_DISPLAY, ReferenceDisplay.reload);
     }
 
     exports.init = init;

--- a/modules/omniStrings.js
+++ b/modules/omniStrings.js
@@ -12,4 +12,5 @@ define(function (require, exports, module) {
     exports.CMD_STOP_OMNISHARP = 'Stop Omnisharp';
     exports.CMD_FIX_CODE_ISSUE = 'Fix Code Issue';
     exports.CMD_OPEN_PREFERENCES = 'Open Preferences';
+    exports.CMD_RELOAD_REFERENCE_DISPLAY = 'Reload References Display';
 });

--- a/preferences.json
+++ b/preferences.json
@@ -2,6 +2,8 @@
     "keyboardShortcuts": {
         "rename": "ctrl-r",
         "goToDefinition": "ctrl-shift-g",
-        "fixCodeIssue": "ctrl-i"
-    }
+        "fixCodeIssue": "ctrl-i",
+        "reloadReferenceDisplay" : "alt-shift-R"
+    },
+    "enableCodeLens" : true
 }


### PR DESCRIPTION
Added the ability to reload codelens/reference display and also a way to turn it off, should we enable/disable it from a keyboard shortcut?

For issue issue #45 